### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  Test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1' # Latest stable release
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1' # Latest stable release
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "SPCSpectra"
 uuid = "ddf1bf59-526a-4a23-8a87-8f8ce489e0c9"
 authors = ["hhaensel <helmut.haensel@gmx.de>"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.2.0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
-julia = "1.4"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -8,3 +8,9 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.2.0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
-julia = "1"
+julia = "1.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/SPCSpectra.jl
+++ b/src/SPCSpectra.jl
@@ -277,10 +277,9 @@ end
 Process each subfile passed to it, extracts header information and data
 information and places them in data members
 Data
-----
-x: x-data (optional)
-y: y-data
-y_int: integer y-data if y-data is not floating
+- x: x-data (optional)
+- y: y-data
+- y_int: integer y-data if y-data is not floating
 """
 function subFile(io::IO, fnpts, fexp, txyxy, tsprec, tmulti)
     # extract subheader info

--- a/src/SPCSpectra.jl
+++ b/src/SPCSpectra.jl
@@ -23,9 +23,7 @@ end
 subhead_siz = 32
 log_siz = 64
 
-# --------------------------
-# units for x,z,w axes
-# --------------------------
+"Units for x,z,w axes."
 const fxtype_op = ["Arbitrary",
                     "Wavenumber (cm-1)",
                     "Micrometers (um)",
@@ -57,10 +55,7 @@ const fxtype_op = ["Arbitrary",
                     "Millimeters (mm)",
                     "Hours"]
 
-# --------------------------
-# units y-axis
-# --------------------------
-
+"Units y-axis."
 const fytype_op = ["Arbitrary Intensity",
                     "Interferogram",
                     "Absorbance",
@@ -116,10 +111,11 @@ read_data(io::IO, ::Type{String}, n::Integer) = strip(String(read(io, n)), '\0')
 read_data(io::IO, T::DataType, n::Integer...) = ltoh.(reshape(reinterpret(T, read(io, prod(n) * sizeof(T))), Int64.(n)...))
 read_data(io::IO, TT::Union{NTuple{N, DataType} where N, Vector{DataType}}) = ltoh.(read.(Ref(io), TT))
 
-# ------------------------------------------------------------------------
-# CONSTRUCTOR
-# ------------------------------------------------------------------------
+"""
+    SPC(filename::AbstractString)
 
+Construct SPC objects.
+"""
 function SPC(filename::AbstractString)
     content = read(filename)
     io = IOBuffer(content)
@@ -276,7 +272,9 @@ function SPC(filename::AbstractString)
 end
 
 """
-Processes each subfile passed to it, extracts header information and data
+    subFile(io::IO, fnpts, fexp, txyxy, tsprec, tmulti)
+
+Process each subfile passed to it, extracts header information and data
 information and places them in data members
 Data
 ----
@@ -329,22 +327,24 @@ function subFile(io::IO, fnpts, fexp, txyxy, tsprec, tmulti)
     x, y
 end
 
+"""
+    read_subheader(io::IO)
+
+Return the subheader as a list:
+-------
+10 item list with the following data members:
+    [1] subflgs
+    [2] subexp
+    [3] subindx
+    [4] subtime
+    [5] subnext
+    [6] subnois
+    [7] subnpts
+    [8] subscan
+    [9] subwlevel
+    [10] subresv
+"""
 function read_subheader(io::IO)
-    """
-    Return the subheader as a list:
-    -------
-    10 item list with the following data members:
-        [1] subflgs
-        [2] subexp
-        [3] subindx
-        [4] subtime
-        [5] subnext
-        [6] subnois
-        [7] subnpts
-        [8] subscan
-        [9] subwlevel
-        [10] subresv
-    """
     subflgs = read_data(io, UInt8)
     subexp = read_data(io, UInt8)
     subindx = read_data(io, Int16)
@@ -359,4 +359,4 @@ function read_subheader(io::IO)
     subflgs, subexp, subindx, subtime, subnext, subnois, subnpts, subscan, subwlevel, subresv
 end
 
-end
+end # module

--- a/src/SPCSpectra.jl
+++ b/src/SPCSpectra.jl
@@ -196,7 +196,7 @@ function SPC(filename::AbstractString)
             read_data(io, Float32, fnpts)
         else
             # otherwise generate them
-            range(ffirst, flast, length = fnpts) |> collect
+            range(ffirst, flast; length=fnpts) |> collect
         end
     end
     # make a list of subfiles

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,7 @@ using Test
 using SPCSpectra
 
 @testset "SPCSpectra" begin
-    pkg_dir = dirname(dirname(pathof(SPCSpectra)))
-    dir = joinpath(pkg_dir, "test", "data")
+    dir = joinpath(pkgdir(SPCSpectra), "test", "data")
     filename = "4d_map.spc"
     path = joinpath(dir, filename)
     spc = SPC(path)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,13 @@
+using Test
+using SPCSpectra
+
+@testset "SPCSpectra" begin
+    dir = joinpath(pkgdir(SPCSpectra), "test", "data")
+    filename = "4d_map.spc"
+    path = joinpath(dir, filename)
+    spc = SPC(path)
+    # The data is from a Nicolet FT-IR spectrometer.
+    # That is, a Fourier infrared spectrometer.
+    @test spc.param_dict["SRC"] == "IR Source"
+    @test spc.param_dict["MODEL"] == "Nicolet"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@ using Test
 using SPCSpectra
 
 @testset "SPCSpectra" begin
-    dir = joinpath(pkgdir(SPCSpectra), "test", "data")
+    pkg_dir = dirname(dirname(pathof(SPCSpectra)))
+    dir = joinpath(pkg_dir, "test", "data")
     filename = "4d_map.spc"
     path = joinpath(dir, filename)
     spc = SPC(path)


### PR DESCRIPTION
- Fixes #2 

This adds a very basic test which verifies that the package can be loaded and parse a file. I've setup testing for the lowest Julia bound that this package supports which is Julia 1.0 and for the latest stable release. It is common for Julia packages to then assume that all versions in between will also work.

Also, I've moved some comments into docstrings. When they are docstrings, people can access the text via `?` in the REPL and that kind of stuff. For example:

```julia
julia> using SPCSpectra

help?> SPCSpectra.fxtype_op
  Units for x,z,w axes.

help?> SPCSpectra.subFile
  subFile(io::IO, fnpts, fexp, txyxy, tsprec, tmulti)

  Process each subfile passed to it, extracts header information and data
  information and places them in data members Data

    •  x: x-data (optional)

    •  y: y-data

    •  y_int: integer y-data if y-data is not floating
```